### PR TITLE
(cargo-release) start next development iteration 0.3.0-alpha.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "emojic"
-version = "0.2.2-alpha.0"
-authors = ["orhanbalci@gmail.com <orhanbalci@gmail.com>"]
+version = "0.3.0-alpha.0"
+authors = ["orhanbalci@gmail.com <orhanbalci@gmail.com>", "Cryptjar <cryptjar@junk.studio>"]
 edition = "2018"
 description = "Emoji constants"
 repository = "https://github.com/orhanbalci/emojic.git"


### PR DESCRIPTION
Since the merging of #3 and #4 the next version should be a breaking update i.e. 0.3.0

I also added me to the authors list (https://github.com/orhanbalci/emojic/issues/2#issuecomment-804239238)