### PR TITLE
Add Flags Example to Readme

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,11 +18,18 @@ required-features = ["alloc"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["alloc"]
-alloc = ["hashbrown"]
+default = ["alloc"]   # default features are automatically enables (if not opt-out)
+alloc = ["hashbrown"] # requires global allocator, enables various functions such as parse_alias
+doc_cfg = []          # requires nightly compiler, only intended for docs.rs builds (enables usage of doc_cfg)
 
 [dependencies]
 lazy_static = "1.4.0"
-hashbrown = { version = "0.11", optional = true }
 
+[dependencies.hashbrown]
+version = "0.11"
+optional = true
+
+
+[package.metadata.docs.rs]
+all-features = true # enable all features when building dos on docs.rs
 

--- a/README.md
+++ b/README.md
@@ -117,6 +117,22 @@ println!("{} ∩ {} ⊂ {} ⊄ {}",
 For more examples have a look at the
 [examples](https://github.com/orhanbalci/emojic/tree/master/examples) folder.
 
+## 🧩 Crate features
+
+This crate is `no_std` by default, means it should be usable in WASM and other restricted
+platforms. However, some functions such as [`parse_alias`](https://docs.rs/emojic/latest/emojic/fn.parse_alias.html) and the
+ad-hoc flag functions need the `alloc` crate (normally part of `std`),
+thus it is enabled by default.
+
+- `default`: (implies `alloc`) automatically enabled if not opt-out:
+  ```toml
+  [dependencies.emojic]
+  version = "0.3"
+  default-features = false
+  ```
+- `alloc`: requires a global allocator, enables various functions such as `parse_alias` as well
+  as the ad-hoc flag functions (the flag constants are unaffected)
+
 
 
 <!-- cargo-sync-readme end -->

--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ Emoji constants for your rusty strings. This crate is inspired by the Go library
 [emoji](https://github.com/enescakir/emoji) written by
 [@enescakir](https://github.com/enescakir).
 
+_Notice that this file uses the actual Unicode emojis to given visual example of the result.
+However, depending on the font and support on your device, not all emojis might be represented
+correctly, especially the newer ones._
+
 
 ## 📦 Cargo.toml
 
@@ -87,12 +91,25 @@ As well as iterators to list all the emojis in each group and subgroup:
 emojic::grouped::people_and_body::hands::base_emojis()
 ```
 
-Finally, it has additional emoji aliases from [github/gemoji](https://github.com/github/gemoji).
+Additionally, it has additional emoji aliases from
+[github/gemoji](https://github.com/github/gemoji).
 
 ```rust
 parse_alias(":+1:") // 👍
 parse_alias(":100:") // 💯
 parse_alias(":woman_astronaut:") // 👩‍🚀
+```
+
+Finally, it has functions to generate (arbitrary) country and regional flags.
+
+```rust
+// 🏴󠁧󠁢󠁥󠁮󠁧󠁿 ∩ 🏴󠁧󠁢󠁳󠁣󠁴󠁿 ⊂ 🇬🇧 ⊄ 🇪🇺
+println!("{} ∩ {} ⊂ {} ⊄ {}",
+    regional_flag("GB-ENG"),
+    regional_flag("GB-SCT"),
+    country_flag("GB"),
+    country_flag("EU"),
+)
 ```
 
 ## 🔭 Examples

--- a/examples/lists.rs
+++ b/examples/lists.rs
@@ -50,9 +50,12 @@ fn main() {
             .collect::<String>()
     );
 
-    // Outputs the each emoji with its full name
-    println!("Geographic places with names:");
+    // Outputs the each emoji with its full name and version of introduction
+    println!("Geographic places with names and version:");
     for emoji in place_geographic::base_emojis() {
-        println!(" - {}: {}", emoji.name, emoji.grapheme);
+        println!(
+            " - {}: {} (since E{})",
+            emoji.name, emoji.grapheme, emoji.since
+        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,10 @@
 //! [emoji](https://github.com/enescakir/emoji) written by
 //! [@enescakir](https://github.com/enescakir).
 //!
+//! _Notice that this file uses the actual Unicode emojis to given visual example of the result.
+//! However, depending on the font and support on your device, not all emojis might be represented
+//! correctly, especially the newer ones._
+//!
 //!
 //! ## 📦 Cargo.toml
 //!
@@ -85,7 +89,8 @@
 //! # assert_eq!("👏🙏🤝👐🤲🙌", text);
 //! ```
 //!
-//! Finally, it has additional emoji aliases from [github/gemoji](https://github.com/github/gemoji).
+//! Additionally, it has additional emoji aliases from
+//! [github/gemoji](https://github.com/github/gemoji).
 //!
 //! ```rust
 //! # use emojic::parse_alias;
@@ -98,6 +103,20 @@
 //! # assert_eq!(Some("👩‍🚀"),
 //! parse_alias(":woman_astronaut:") // 👩‍🚀
 //! # .map(|e| e.grapheme));
+//! ```
+//!
+//! Finally, it has functions to generate (arbitrary) country and regional flags.
+//!
+//! ```rust
+//! # use emojic::regional_flag;
+//! # use emojic::country_flag;
+//! // 🏴󠁧󠁢󠁥󠁮󠁧󠁿 ∩ 🏴󠁧󠁢󠁳󠁣󠁴󠁿 ⊂ 🇬🇧 ⊄ 🇪🇺
+//! println!("{} ∩ {} ⊂ {} ⊄ {}",
+//!     regional_flag("GB-ENG"),
+//!     regional_flag("GB-SCT"),
+//!     country_flag("GB"),
+//!     country_flag("EU"),
+//! )
 //! ```
 //!
 //! ## 🔭 Examples
@@ -177,8 +196,13 @@ pub fn parse_alias(inp: &str) -> Option<&'static Emoji> {
 /// ```
 /// use emojic::country_flag;
 ///
-/// assert_eq!(country_flag("EU"), emojic::flat::FLAG_EUROPEAN_UNION.to_string()); // 🇪🇺
-/// println!("{}", country_flag("ZZ")); // 🇿🇿 (an invalid flag)
+/// assert_eq!(
+///     country_flag("EU"), // 🇪🇺
+///     emojic::flat::FLAG_EUROPEAN_UNION.to_string()
+/// );
+/// println!("{}",
+///     country_flag("ZZ"), // 🇿🇿 (an invalid flag)
+/// );
 /// ```
 #[cfg(feature = "alloc")]
 pub fn country_flag(country_code: &str) -> String {
@@ -211,7 +235,7 @@ pub fn country_flag(country_code: &str) -> String {
 #[doc(hidden)] // we don't really need this in the docs.
 #[deprecated = "Just use country_flag instead (with U)"]
 pub fn contry_flag(country_code: &str) -> String {
-	country_flag(country_code)
+    country_flag(country_code)
 }
 
 
@@ -230,8 +254,13 @@ pub fn contry_flag(country_code: &str) -> String {
 /// ```
 /// use emojic::regional_flag;
 ///
-/// assert_eq!(regional_flag("GB-ENG"), emojic::flat::FLAG_ENGLAND.to_string()); // 🏴󠁧󠁢󠁥󠁮󠁧󠁿 (England region of United Kingdom (GB))
-/// println!("{}", regional_flag("ZZ-ABC")); // 🏴󠁺󠁺󠁡󠁢󠁣󠁿 (an invalid flag)
+/// assert_eq!(
+///     regional_flag("GB-ENG"), // 🏴󠁧󠁢󠁥󠁮󠁧󠁿 (England region of United Kingdom (GB))
+///     emojic::flat::FLAG_ENGLAND.to_string()
+/// );
+/// println!("{}",
+///     regional_flag("ZZ-ABC") // 🏴󠁺󠁺󠁡󠁢󠁣󠁿 (an invalid flag)
+/// );
 /// ```
 #[cfg(feature = "alloc")]
 pub fn regional_flag(regional_code: &str) -> String {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -175,13 +175,13 @@ pub fn parse_alias(inp: &str) -> Option<&'static Emoji> {
 ///
 /// # Examples
 /// ```
-/// use emojic::contry_flag;
+/// use emojic::country_flag;
 ///
-/// assert_eq!(contry_flag("EU"), emojic::flat::FLAG_EUROPEAN_UNION.to_string()); // 🇪🇺
-/// println!("{}", contry_flag("ZZ")); // 🇿🇿 (an invalid flag)
+/// assert_eq!(country_flag("EU"), emojic::flat::FLAG_EUROPEAN_UNION.to_string()); // 🇪🇺
+/// println!("{}", country_flag("ZZ")); // 🇿🇿 (an invalid flag)
 /// ```
 #[cfg(feature = "alloc")]
-pub fn contry_flag(country_code: &str) -> String {
+pub fn country_flag(country_code: &str) -> String {
     assert!(
         country_code.chars().all(|c| c.is_ascii_alphabetic()),
         "Only chars A-Z are allowed as country_code"
@@ -197,6 +197,23 @@ pub fn contry_flag(country_code: &str) -> String {
         .map(|c| core::char::from_u32(c as u32 - 'A' as u32 + '\u{1F1E6}' as u32).unwrap())
         .collect()
 }
+
+
+// TODO: Remove `contry_flag` (without U) before releasing v0.4.0!
+
+// That's embarrassing: Originally `country_flag` had been misspelled as `contry_flag`
+// and with that name it has been released as v0.3.0!
+// Therefore, this misspelled function is kept here to keep it compatible, however it will just
+// redirect to the now correctly named function.
+
+/// Generate an ad-hoc country flag (use [`country_flag`] instead).
+#[cfg(feature = "alloc")]
+#[doc(hidden)] // we don't really need this in the docs.
+#[deprecated = "Just use country_flag instead (with U)"]
+pub fn contry_flag(country_code: &str) -> String {
+	country_flag(country_code)
+}
+
 
 /// Generate an ad-hoc regional flag.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,12 @@
 #![no_std]
 
+// Enable annotating features requirements in docs
+#![cfg_attr(feature = "doc_cfg", feature(doc_cfg))]
+
+// Ensures that `pub` means published in the public API.
+// This property is useful for reasoning about breaking API changes.
+#![deny(unreachable_pub)]
+
 //!
 //! Emoji constants for your rusty strings. This crate is inspired by the Go library
 //! [emoji](https://github.com/enescakir/emoji) written by
@@ -93,6 +100,7 @@
 //! [github/gemoji](https://github.com/github/gemoji).
 //!
 //! ```rust
+//! # #[cfg(feature = "alloc")]{ // Only with `alloc`
 //! # use emojic::parse_alias;
 //! # assert_eq!(Some("👍"),
 //! parse_alias(":+1:") // 👍
@@ -103,11 +111,13 @@
 //! # assert_eq!(Some("👩‍🚀"),
 //! parse_alias(":woman_astronaut:") // 👩‍🚀
 //! # .map(|e| e.grapheme));
+//! # } // Only with `alloc`
 //! ```
 //!
 //! Finally, it has functions to generate (arbitrary) country and regional flags.
 //!
 //! ```rust
+//! # #[cfg(feature = "alloc")]{ // Only with `alloc`
 //! # use emojic::regional_flag;
 //! # use emojic::country_flag;
 //! // 🏴󠁧󠁢󠁥󠁮󠁧󠁿 ∩ 🏴󠁧󠁢󠁳󠁣󠁴󠁿 ⊂ 🇬🇧 ⊄ 🇪🇺
@@ -117,12 +127,29 @@
 //!     country_flag("GB"),
 //!     country_flag("EU"),
 //! )
+//! # } // Only with `alloc`
 //! ```
 //!
 //! ## 🔭 Examples
 //!
 //! For more examples have a look at the
 //! [examples](https://github.com/orhanbalci/emojic/tree/master/examples) folder.
+//!
+//! ## 🧩 Crate features
+//!
+//! This crate is `no_std` by default, means it should be usable in WASM and other restricted
+//! platforms. However, some functions such as [`parse_alias`](crate::parse_alias) and the
+//! ad-hoc flag functions need the `alloc` crate (normally part of `std`),
+//! thus it is enabled by default.
+//!
+//! - `default`: (implies `alloc`) automatically enabled if not opt-out:
+//!   ```toml
+//!   [dependencies.emojic]
+//!   version = "0.3"
+//!   default-features = false
+//!   ```
+//! - `alloc`: requires a global allocator, enables various functions such as `parse_alias` as well
+//!   as the ad-hoc flag functions (the flag constants are unaffected)
 //!
 //!
 
@@ -176,6 +203,7 @@ use emojis::Emoji;
 /// ```
 ///
 #[cfg(feature = "alloc")]
+#[cfg_attr(feature = "doc_cfg", doc(cfg(feature = "alloc")))]
 pub fn parse_alias(inp: &str) -> Option<&'static Emoji> {
     alias::GEMOJI_MAP.get(inp).cloned()
 }
@@ -205,6 +233,7 @@ pub fn parse_alias(inp: &str) -> Option<&'static Emoji> {
 /// );
 /// ```
 #[cfg(feature = "alloc")]
+#[cfg_attr(feature = "doc_cfg", doc(cfg(feature = "alloc")))]
 pub fn country_flag(country_code: &str) -> String {
     assert!(
         country_code.chars().all(|c| c.is_ascii_alphabetic()),
@@ -263,6 +292,7 @@ pub fn contry_flag(country_code: &str) -> String {
 /// );
 /// ```
 #[cfg(feature = "alloc")]
+#[cfg_attr(feature = "doc_cfg", doc(cfg(feature = "alloc")))]
 pub fn regional_flag(regional_code: &str) -> String {
     assert!(
         regional_code


### PR DESCRIPTION
First, this PR fixes the spelling of the `contry_flag` (sic) function to `country_flag` 😳
Since that wrongly named function is already published and to prevent making yet another breaking change, that function is kept and only marked `deprecated`, it's now also hidden from docs. So it is backwards compatible and may be included in e.g. version 0.3.1.

The actual (initial) purpose of this PR is to add an example of the flag functions to the README file (https://github.com/orhanbalci/emojic/issues/5#issuecomment-811784676). At this opportunity, I also documented the crate-features and added a comment about the `no_std` capability. And to better document the effect of the crate-features (i.e. `alloc`), I added another (undocumented) crate-feature to use the [nightly `doc_cfg` feature](https://doc.rust-lang.org/beta/unstable-book/language-features/doc-cfg.html) (which will be used by docs.rs) to add nice markers to those functions depending on `alloc`.