### PR TITLE
Update the version tags in the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ correctly, especially the newer ones._
 
 ```toml
 [dependencies]
-emojic = "0.3"
+emojic = "0.4"
 ```
 
 ## 🔧 Example
@@ -138,7 +138,7 @@ thus it is enabled by default.
   Automatically enabled if not opt-out:
   ```toml
   [dependencies.emojic]
-  version = "0.3"
+  version = "0.4"
   default-features = false
   ```
 - `alloc`: (implies `hashbrown` and `lazy_static`) \

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! emojic = "0.3"
+//! emojic = "0.4"
 //! ```
 //!
 //! ## 🔧 Example
@@ -165,7 +165,7 @@
 //!   Automatically enabled if not opt-out:
 //!   ```toml
 //!   [dependencies.emojic]
-//!   version = "0.3"
+//!   version = "0.4"
 //!   default-features = false
 //!   ```
 //! - `alloc`: (implies `hashbrown` and `lazy_static`) \


### PR DESCRIPTION
Since the latest release of v0.4.0, the versions mentioned in the README and crate-level docs should be updated too.